### PR TITLE
Fix Login Page Photos Source For Unavailable Image

### DIFF
--- a/src/Login.css
+++ b/src/Login.css
@@ -1,7 +1,8 @@
 .login {
     display: grid;
     place-items: center;
-    height: 100vh;
+    height: 50vh;
+    padding-top: 10%;
 }
 
 .login > button {

--- a/src/Login.js
+++ b/src/Login.js
@@ -8,7 +8,6 @@ import { actionTypes } from './reducer'
 function Login() {
     const [state, dispatch] = useStateValue()
 
-
     const signIn = () => {
         auth.signInWithPopup(provider).then((result) => {
 
@@ -25,9 +24,7 @@ function Login() {
             <div className="login__logo">
                 <img src="https://1.bp.blogspot.com/-S8HTBQqmfcs/XN0ACIRD9PI/AAAAAAAAAlo/FLhccuLdMfIFLhocRjWqsr9cVGdTN_8sgCPcBGAYYCw/s1600/f_logo_RGB-Blue_1024.png" alt="" />
 
-                <img
-
-                    src="https://marka-logo.com/wp-content/uploads/2020/04/Facebook-Logo.png" alt="" />
+                <img src="https://ar.toneden.io/41964521/15478342-010c-44d8-926c-1ece6a59210e" alt="" />
             </div>
             <Button type="submit" onClick={signIn}>
                 Sign In


### PR DESCRIPTION
#1 , Buradaki resim kesintisini düzelttim ve [login.css](https://github.com/MertCankaya/Facebook-Clone/blob/main/src/Login.css) üzerinde `height` ve `margin-top` konfigürasyonlarını yaptım. Ayrıca, resim kesintisi için farklı bir kaynaktan resim referans aldım. Fakat, bu kaynağın ileride tekrardan bir kesintiye ulaşıp ulaşmayacağı bilinmediği için resmin bir host sunucusunda depolanıp oradan referans alınması gerektiğini düşünüyorum.

Bu değişiklikler, insanların bu demoyu test etmesi için hesaplarını girmeleri için daha da güvenilir bir bakış oluşturacaktır.